### PR TITLE
Push Metadata about ENums to the backend

### DIFF
--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -13,7 +13,9 @@ from func_adl_servicex_type_generator.class_utils import (
 )
 from func_adl_servicex_type_generator.data_model import (
     class_info,
+    enum_info,
     file_info,
+    method_arg_info,
     method_info,
 )
 
@@ -399,7 +401,58 @@ def write_out_classes(
 
             return r
 
+        def lookup_enum(
+            arg: method_arg_info, all_classes: Iterable[class_info]
+        ) -> Optional[enum_info]:
+            """Return the enum info for the argument if it is an enum.
+
+            Args:
+                arg (method_info): The argument to check
+                all_classes (Iterable[class_info]): All classes to look through
+
+            Returns:
+                Optional[enum_info]: The enum info if this is an enum, or None
+            """
+            cpp_type = clean_cpp_type(arg.arg_type)
+            if cpp_type is None:
+                return None
+            cpp_type_info = cpp_type.rsplit(".", 2)
+
+            for c in all_classes:
+                for e in c.enums:
+                    if e.name == cpp_type_info[1] and cpp_type_info[0] == c.cpp_name:
+                        return e
+
+            return None
+
+        def generate_enums(
+            method_list: List[method_info], all_classes: Iterable[class_info]
+        ) -> Dict[str, List[enum_info]]:
+            """Return a list of the referenced enum definitions for this call.
+
+            Args:
+                method_list (List[method_info]): List of the methods that we need to look at
+                all_classes (List[class_info]): List of all classes (and thus enums in them)
+
+            Raises:
+                RuntimeError: _description_
+
+            Returns:
+                Dict[str, Dict[str, Any]]: List, by method name, of all enums referenced.
+            """
+            result: Dict[str, List[enum_info]] = {
+                m.name: [
+                    e_info
+                    for arg in m.arguments
+                    if (e_info := lookup_enum(arg, all_classes)) is not None
+                ]
+                for m in method_list
+                if m.return_type is not None
+            }
+            return result
+
         methods = generate_methods(c.methods)
+        referenced_enums = generate_enums(c.methods, all_classes)
 
         # Methods from behavior as classes
         for b in c.behaviors:
@@ -424,6 +477,7 @@ def write_out_classes(
             methods_info=methods,
             package_name=package_name,
             enums_info=c.enums,
+            referenced_enums=referenced_enums,
         )
 
         with class_file.open("wt") as out:

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -413,10 +413,15 @@ def write_out_classes(
             Returns:
                 Optional[enum_info]: The enum info if this is an enum, or None
             """
+            # Split into namespace and enum type. We don't deal with
+            # global enums here, so if this isn't a class-enum, then
+            # just return.
             cpp_type = clean_cpp_type(arg.arg_type)
             if cpp_type is None:
                 return None
             cpp_type_info = cpp_type.rsplit(".", 2)
+            if len(cpp_type_info) != 2:
+                return None
 
             for c in all_classes:
                 for e in c.enums:
@@ -428,6 +433,15 @@ def write_out_classes(
         def get_referenced_enums(
             m: method_info, all_classes: Iterable[class_info]
         ) -> List[Tuple[class_info, enum_info]]:
+            """Get referenced enums in a method
+
+            Args:
+                m (method_info): The method to check for referenced enums
+                all_classes (Iterable[class_info]): The list of classes we can go search for enums
+
+            Returns:
+                List[Tuple[class_info, enum_info]]: List of the class and enum that was referenced.
+            """
             return [
                 e_info
                 for arg in m.arguments

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -24,6 +24,20 @@ _method_map = {
 {%- endfor %}
 }
 
+_enum_map = {
+{%- for enum in enums_info %}
+    '{{ enum.name }}': {
+        'metadata_type': 'define_enum',
+        'namespace': '{{ class_name }}',
+        'name': '{{ enum.name }}',
+        'values': [
+        {%- for value in enum.values %}
+            '{{ value.name }}',
+        {%- endfor %}
+        ],
+    },
+{%- endfor %}      
+}
 
 T = TypeVar('T')
 

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -25,17 +25,21 @@ _method_map = {
 }
 
 _enum_map = {
-{%- for enum in enums_info %}
-    '{{ enum.name }}': {
-        'metadata_type': 'define_enum',
-        'namespace': '{{ class_name }}',
-        'name': '{{ enum.name }}',
-        'values': [
-        {%- for value in enum.values %}
-            '{{ value.name }}',
-        {%- endfor %}
-        ],
-    },
+{%- for method_name in referenced_enums.keys() %}
+    '{{ method_name }}': [
+{%- for enum in referenced_enums[method_name] %}
+        '{{ enum.name }}': {
+            'metadata_type': 'define_enum',
+            'namespace': '{{ class_name }}',
+            'name': '{{ enum.name }}',
+            'values': [
+            {%- for value in enum.values %}
+                '{{ value.name }}',
+            {%- endfor %}
+            ],
+        },
+{%- endfor %}
+    ],
 {%- endfor %}      
 }
 

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -28,12 +28,12 @@ _enum_map = {
 {%- for method_name in referenced_enums.keys() %}
     '{{ method_name }}': [
 {%- for enum in referenced_enums[method_name] %}
-        '{{ enum.name }}': {
+        {
             'metadata_type': 'define_enum',
-            'namespace': '{{ class_name }}',
-            'name': '{{ enum.name }}',
+            'namespace': '{{ enum[0].name }}',
+            'name': '{{ enum[1].name }}',
             'values': [
-            {%- for value in enum.values %}
+            {%- for value in enum[1].values %}
                 '{{ value.name }}',
             {%- endfor %}
             ],

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -59,6 +59,8 @@ def _add_method_metadata(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[
             'body_includes': ["{{ include_file }}"],
         })
 {%- endif %}
+        for md in _enum_map.get(a.func.attr, []):
+            s_update = s_update.MetaData(md)
         return s_update, a
     else:
         return s, a

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -706,10 +706,10 @@ def test_class_with_just_enum(tmp_path, template_path):
     assert "Red = 1" in class_text
     assert "from enum import Enum" in class_text
 
-    assert '"metadata_type": "define_enum"' in class_text
-    assert '"namespace": "Jets"' in class_text
-    assert '"name": "Color"' in class_text
-    assert '"values": ["Red"]' in class_text
+    assert "'metadata_type': 'define_enum'" in class_text
+    assert "'namespace': 'Jets'" in class_text
+    assert "'name': 'Color'" in class_text
+    assert "'Red'" in class_text
 
 
 def test_class_with_external_enum(tmp_path, template_path):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -706,10 +706,7 @@ def test_class_with_just_enum(tmp_path, template_path):
     assert "Red = 1" in class_text
     assert "from enum import Enum" in class_text
 
-    assert "'metadata_type': 'define_enum'" in class_text
-    assert "'namespace': 'Jets'" in class_text
-    assert "'name': 'Color'" in class_text
-    assert "'Red'" in class_text
+    assert "'metadata_type': 'define_enum'" not in class_text
 
 
 def test_class_with_external_enum(tmp_path, template_path):
@@ -765,11 +762,8 @@ def test_class_with_external_enum(tmp_path, template_path):
 
 
 def test_class_with_referenced_enum(tmp_path, template_path):
-    """Two classes. One with enums, and the other class uses
-    those enums.
-
-    - Make sure the import works correctly
-    - Make sure the enum is fully qualified in its reference.
+    """Make sure to reference a local enum in the class, and set metadata
+    correctly.
     """
     classes = [
         class_info(
@@ -804,6 +798,11 @@ def test_class_with_referenced_enum(tmp_path, template_path):
     class_text = (tmp_path / "jets.py").read_text()
     assert "class Color(Enum)" in class_text
     assert "def pt_enum(self, color: Jets.Color) -> float" in class_text
+
+    assert "'metadata_type': 'define_enum'" in class_text
+    assert "'namespace': 'Jets'" in class_text
+    assert "'name': 'Color'" in class_text
+    assert "'Red'" in class_text
 
 
 def test_class_with_just_enums(tmp_path, template_path):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -808,6 +808,44 @@ def test_class_with_referenced_enum(tmp_path, template_path):
     assert "'Red'" in class_text
 
 
+def test_class_with_enum_and_int(tmp_path, template_path):
+    """Make sure to reference a local enum in the class, and set metadata
+    correctly.
+    """
+    classes = [
+        class_info(
+            "Jets",
+            "Jets",
+            [
+                method_info(
+                    name="pt_enum",
+                    return_type="float",
+                    arguments=[method_arg_info("color", None, "int")],
+                    param_arguments=[],
+                    param_helper=None,
+                )
+            ],
+            None,
+            None,
+            "jet.hpp",
+            enums=[
+                enum_info(
+                    name="Color",
+                    values=[enum_value_info("Red", 1), enum_value_info("Blue", 2)],
+                )
+            ],
+        ),
+    ]
+
+    write_out_classes(classes, template_path, tmp_path, "package", "22")
+
+    assert (tmp_path / "jets.py").exists()
+    assert (tmp_path / "__init__.py").exists()
+
+    class_text = (tmp_path / "jets.py").read_text()
+    assert "'metadata_type': 'define_enum'" not in class_text
+
+
 def test_class_with_just_enums(tmp_path, template_path):
     """Write out a very simple top level class with enum
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -706,6 +706,11 @@ def test_class_with_just_enum(tmp_path, template_path):
     assert "Red = 1" in class_text
     assert "from enum import Enum" in class_text
 
+    assert '"metadata_type": "define_enum"' in class_text
+    assert '"namespace": "Jets"' in class_text
+    assert '"name": "Color"' in class_text
+    assert '"values": ["Red"]' in class_text
+
 
 def test_class_with_external_enum(tmp_path, template_path):
     """Two classes. One with enums, and the other class uses

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -760,6 +760,9 @@ def test_class_with_external_enum(tmp_path, template_path):
     )
     assert "import package" in class_text
 
+    assert "define_enum" in class_text
+    assert "'namespace': 'EnumOnly'" in class_text
+
 
 def test_class_with_referenced_enum(tmp_path, template_path):
     """Make sure to reference a local enum in the class, and set metadata


### PR DESCRIPTION
This PR adds metadata to the query connected with enums. In this way it can be transmitted to the backend and properly processed.

* Find metadata for enums defined in class in a seperate class
* Add metadata to a `Metadata` predicate that is transmitted to the backend.
* Add some simple testing to make sure the metadata code is properly generated.


Fixes #16