### PR TITLE
Use func_adl_servicex solid releases

### DIFF
--- a/template/package/pyproject.toml
+++ b/template/package/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-func_adl_servicex = { version = "^2.0-beta.1", allow-prereleases = true }
+func_adl_servicex = { version = "^2.0" }
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
* Do not specify pre-releases any longer.

Fixes #18