### PR TITLE
Make for multiple release imports

### DIFF
--- a/func_adl_servicex_type_generator/generator.py
+++ b/func_adl_servicex_type_generator/generator.py
@@ -111,7 +111,7 @@ def generate_package(
         template_path,
         output_path / template_data["package_name"],
         package_name,
-        str(release_tuple[0]),
+        [ds[0] for ds in dataset_types],
         base_init_lines=base_init_lines,
         config_vars=data.config,
     )

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -285,7 +285,7 @@ def write_out_classes(
     template_path: Path,
     project_src_path: Path,
     package_name: str,
-    release_series: str,
+    dataset_types: List[str],
     base_init_lines: List[str] = [],
     config_vars: Dict[str, str] = {},
 ):
@@ -299,7 +299,7 @@ def write_out_classes(
         project_src_path (Path): The root of the package source directory
             (top level __init__.py file location)
         project_name (str): Name of package for use in import statements
-        release_series (str): Which release is this (22, or 21, etc.)
+        dataset_types (List[str]): Which release is this (22, or 21, etc.)
     """
     # Load up the template structure and environment
     loader = jinja2.FileSystemLoader(str(template_path / "files"))
@@ -524,7 +524,7 @@ def write_out_classes(
                     module_stub=m_stub,
                     sub_namespaces=sub_ns,
                     package_name=package_name,
-                    sx_dataset_name=f"SXDSAtlasxAODR{release_series}",
+                    sx_dataset_name=dataset_types,
                     base_init_lines=base_init_lines,
                     base_variables=[config_info(k, v) for k, v in config_vars.items()],
                 )

--- a/template/files/__init__.py
+++ b/template/files/__init__.py
@@ -1,7 +1,9 @@
 from typing import Any, TYPE_CHECKING
 {%- if module_stub == "" %}
 try:
-    from .sx_dataset import {{ sx_dataset_name }}
+{%- for sx_ds in sx_dataset_name %}
+    from .sx_dataset import {{ sx_ds }}
+{%- endfor %}
 except ImportError:
     pass
 from .func_adl_iterable import FADLStream

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -890,13 +890,42 @@ def test_class_simple_release_different(tmp_path, template_path):
         class_info("Jets", "Jets", [], None, None, "jet.hpp"),
     ]
 
-    write_out_classes(classes, template_path, tmp_path, "package", "101")
+    write_out_classes(
+        classes, template_path, tmp_path, "package", ["SXDSAtlasxAODR101"]
+    )
 
     assert (tmp_path / "jets.py").exists()
     assert (tmp_path / "__init__.py").exists()
 
     init_text = (tmp_path / "__init__.py").read_text()
     assert "SXDSAtlasxAODR101" in init_text
+
+
+def test_class_simple_multiple_calib_release(tmp_path, template_path):
+    """Write out multiple calibration types
+
+    Args:
+        tmp_path ([type]): [description]
+    """
+    classes = [
+        class_info("Jets", "Jets", [], None, None, "jet.hpp"),
+    ]
+
+    write_out_classes(
+        classes,
+        template_path,
+        tmp_path,
+        "package",
+        ["SXDSAtlasxAODR101", "SXDSAtlasxAODR101PHYS", "SXDSAtlasxAODR101PHYSLITE"],
+    )
+
+    assert (tmp_path / "jets.py").exists()
+    assert (tmp_path / "__init__.py").exists()
+
+    init_text = (tmp_path / "__init__.py").read_text()
+    assert "SXDSAtlasxAODR101" in init_text
+    assert "SXDSAtlasxAODR101PHYS" in init_text
+    assert "SXDSAtlasxAODR101PHYSLITE" in init_text
 
 
 def test_class_with_init_config(tmp_path, template_path):


### PR DESCRIPTION
We already generate datasets by calibration. This just makes it easier to import those datasets.

* Generate dataset types for everything that is generated in `sx_dataset`
* Add tests to make sure the (now simpler) code works.

Fixes #20
