### PR TITLE
Allow for multiple include files and track libraries

### DIFF
--- a/func_adl_servicex_type_generator/data_model.py
+++ b/func_adl_servicex_type_generator/data_model.py
@@ -169,6 +169,9 @@ class class_info:
     # The include file that needs to be loaded for this class
     include_file: str
 
+    # The library this guy is in
+    library: Optional[str] = None
+
     # If this is an alias marker or not
     is_alias: bool = False
 

--- a/func_adl_servicex_type_generator/data_model.py
+++ b/func_adl_servicex_type_generator/data_model.py
@@ -169,9 +169,6 @@ class class_info:
     # The include file that needs to be loaded for this class
     include_file: str
 
-    # The library this guy is in
-    library: Optional[str] = None
-
     # If this is an alias marker or not
     is_alias: bool = False
 
@@ -180,6 +177,9 @@ class class_info:
 
     # The list of enums we have
     enums: List[enum_info] = field(default_factory=list)
+
+    # The library this guy is in
+    library: Optional[str] = None
 
 
 @dataclass

--- a/func_adl_servicex_type_generator/loader.py
+++ b/func_adl_servicex_type_generator/loader.py
@@ -188,6 +188,7 @@ def load_yaml(
             is_alias=("is_alias" in c) and (c["is_alias"] == "True"),
             behaviors=c["also_behaves_like"] if "also_behaves_like" in c else [],
             enums=enum_loader(c["enums"]) if "enums" in c else [],
+            library=c["library"] if "library" in c else None,
         )
         for c in data_classes
     ]

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -472,6 +472,7 @@ def write_out_classes(
         referenced_enums = generate_enums(c.methods, all_classes)
 
         # Methods from behavior as classes
+        all_includes = [c.include_file] if c.include_file != "" else []
         for b in c.behaviors:
             name = clean_cpp_type(b)
             assert name is not None
@@ -480,12 +481,14 @@ def write_out_classes(
             methods += generate_methods(
                 cpp_all_classes_dict[name].methods, count_pointer_depth(b)
             )
+            if cpp_all_classes_dict[name].include_file != "":
+                all_includes.append(cpp_all_classes_dict[name].include_file)
 
         # Write out the object file
         text = class_template_file.render(
             class_name=c_name,
             methods=c.methods,
-            include_file=c.include_file,
+            include_files=all_includes,
             import_statements=import_statements,
             class_split_namespace=class_split_namespace,
             remove_ns_stem=remove_ns_stem,

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -473,6 +473,7 @@ def write_out_classes(
 
         # Methods from behavior as classes
         all_includes = [c.include_file] if c.include_file != "" else []
+        all_libraries = [c.library] if c.library is not None else []
         for b in c.behaviors:
             name = clean_cpp_type(b)
             assert name is not None
@@ -481,8 +482,11 @@ def write_out_classes(
             methods += generate_methods(
                 cpp_all_classes_dict[name].methods, count_pointer_depth(b)
             )
-            if cpp_all_classes_dict[name].include_file != "":
-                all_includes.append(cpp_all_classes_dict[name].include_file)
+            b_class = cpp_all_classes_dict[name]
+            if b_class.include_file != "":
+                all_includes.append(b_class.include_file)
+            if b_class.library is not None:
+                all_libraries.append(b_class.library)
 
         # Write out the object file
         text = class_template_file.render(
@@ -498,6 +502,7 @@ def write_out_classes(
             package_name=package_name,
             enums_info=c.enums,
             referenced_enums=referenced_enums,
+            libraries=all_libraries,
         )
 
         with class_file.open("wt") as out:

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -52,13 +52,13 @@ def _add_method_metadata(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[
     assert isinstance(a.func, ast.Attribute)
     if a.func.attr in _method_map:
         s_update = s.MetaData(_method_map[a.func.attr])
-{%- if include_file != "" %}
+{% for i_file in include_files %}
         s_update = s_update.MetaData({
             'metadata_type': 'inject_code',
-            'name': '{{ include_file }}',
-            'body_includes': ["{{ include_file }}"],
+            'name': '{{ i_file }}',
+            'body_includes': ["{{ i_file }}"],
         })
-{%- endif %}
+{% endfor %}
         for md in _enum_map.get(a.func.attr, []):
             s_update = s_update.MetaData(md)
         return s_update, a

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -59,6 +59,13 @@ def _add_method_metadata(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[
             'body_includes': ["{{ i_file }}"],
         })
 {% endfor %}
+{% for l_file in libraries %}
+        s_update = s_update.MetaData({
+            'metadata_type': 'inject_code',
+            'name': '{{ l_file }}',
+            'link_libraries': ["{{ l_file }}"],
+        })
+{% endfor %}
         for md in _enum_map.get(a.func.attr, []):
             s_update = s_update.MetaData(md)
         return s_update, a

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,5 @@
 from pathlib import Path
-from func_adl_servicex_type_generator.loader import load_yaml, class_info, metadata_info
-import yaml
+from func_adl_servicex_type_generator.loader import load_yaml
 
 
 def test_load_full_file():

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from func_adl_servicex_type_generator.loader import load_yaml
+from func_adl_servicex_type_generator.loader import load_yaml, class_info, metadata_info
+import yaml
 
 
 def test_load_full_file():
@@ -12,7 +13,6 @@ def test_load_full_file():
     assert "xAOD.Jet_v1" in classes_dict
 
     di_jets = collection_dict["DiTauJets"]
-    # jets = collection_dict["Jets"]
     jets_class = classes_dict["xAOD.Jet_v1"]
     btagging = classes_dict["xAOD.BTagging_v1"]
     truth = classes_dict["xAOD.TruthParticle_v1"]
@@ -27,6 +27,7 @@ def test_load_full_file():
     assert di_jets.cpp_collection_type == "DataVector<xAOD::DiTauJet_v1>"
 
     assert jets_class.name == "xAOD.Jet_v1"
+    assert jets_class.library == "xAODJet"
     assert len(jets_class.methods) > 0
     pt_methods = [m for m in jets_class.methods if m.name == "pt"]
     assert len(pt_methods) == 1
@@ -45,6 +46,7 @@ def test_load_full_file():
     assert len(calc_llr) == 1
     assert len(calc_llr[0].arguments) == 2
     assert calc_llr[0].arguments[0].arg_type == "float"
+    assert btagging.library is None
 
     assert len(event_info.cpp_include_file) == 1
     assert event_info.link_libraries == ["xAODEventInfo"]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1247,6 +1247,7 @@ def test_method_with_behavior_includes(tmp_path, template_path):
             None,
             None,
             "Tracks.hpp",
+            library="xAODTrack",
         ),
     ]
 
@@ -1255,6 +1256,7 @@ def test_method_with_behavior_includes(tmp_path, template_path):
     all_text = (tmp_path / "xAOD" / "jets.py").read_text()
     assert "jet.hpp" in all_text
     assert "Tracks.hpp" in all_text
+    assert "xAODTrack" in all_text
 
 
 def test_method_with_behavior_deref(tmp_path, template_path):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1208,6 +1208,55 @@ def test_method_with_behavior(tmp_path, template_path):
     assert "deref_count" not in all_text
 
 
+def test_method_with_behavior_includes(tmp_path, template_path):
+    """Make sure that connected classes include their includes.
+
+    Args:
+        tmp_path ([type]): [description]
+    """
+    classes = [
+        class_info(
+            "xAOD.Jets",
+            "xAOD::Jets",
+            [
+                method_info(
+                    name="pt1",
+                    return_type="float",
+                    arguments=[],
+                    param_arguments=[],
+                    param_helper=None,
+                )
+            ],
+            None,
+            None,
+            "jet.hpp",
+            behaviors=["xAOD::Tracks"],
+        ),
+        class_info(
+            "xAOD.Tracks",
+            "xAOD::Tracks",
+            [
+                method_info(
+                    name="pt2",
+                    return_type="float",
+                    arguments=[],
+                    param_arguments=[],
+                    param_helper=None,
+                )
+            ],
+            None,
+            None,
+            "Tracks.hpp",
+        ),
+    ]
+
+    write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
+
+    all_text = (tmp_path / "xAOD" / "jets.py").read_text()
+    assert "jet.hpp" in all_text
+    assert "Tracks.hpp" in all_text
+
+
 def test_method_with_behavior_deref(tmp_path, template_path):
     """Write out a very simple top level class with a method.
 

--- a/tests/xaod_r21_1.yaml
+++ b/tests/xaod_r21_1.yaml
@@ -2579,6 +2579,7 @@ classes:
   - python_name: xAOD.Jet_v1
     cpp_name: xAOD::Jet_v1
     include_file: xAODJet/versions/Jet_v1.h
+    library: "xAODJet"
     methods:
       - name: pt
         return_type: double


### PR DESCRIPTION
Addressing two oversights in how we build type systems:

* We use `behavies-like` when capturing pointers - like `ElementLinks`. This code was not correctly adding include files.
* The link libraries were also not being tracked.
* This was previously only tracked for collections - now it is tracked for classes as well.

Basically, the old model worked by assuming a "new" class would be used only when accessing collections. This overlooks the possibiliity that a jet can point to tracks. 

To work this requires new information from the type generators, and also increases the amount of metadata that is sent down to the backend.

When a class behaves like another class, it should also include its headers 
Fixes #32