### PR TITLE
Ensure 'string' is associated with 'str' in type mapping

### DIFF
--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -163,6 +163,7 @@ _g_cpp_to_py_type_map = {
     "uint16_t": "int",
     "uint8_t": "int",
     "char": "str",
+    "string": "str",
 }
 
 _g_py_single_types = {i for _, i in _g_cpp_to_py_type_map.items()}


### PR DESCRIPTION
Add association for the 'string' type to the existing mapping for 'str' to maintain consistency in type handling.

Fixes #40