### PR TITLE
push enum metadata for enum return types

### DIFF
--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -15,7 +15,6 @@ from func_adl_servicex_type_generator.data_model import (
     class_info,
     enum_info,
     file_info,
-    method_arg_info,
     method_info,
 )
 

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -413,25 +413,20 @@ def write_out_classes(
             """Return the enum info for the argument if it is an enum.
 
             Args:
-                arg (method_info): The argument to check
+                arg (method_info): The argument to check (python type)
                 all_classes (Iterable[class_info]): All classes to look through
 
             Returns:
                 Optional[enum_info]: The enum info if this is an enum, or None
             """
-            # Split into namespace and enum type. We don't deal with
-            # global enums here, so if this isn't a class-enum, then
-            # just return.
-            cpp_type = clean_cpp_type(arg)
-            if cpp_type is None:
-                return None
-            cpp_type_info = cpp_type.rsplit(".", 2)
-            if len(cpp_type_info) != 2:
+            # Split into namespace and enum type.
+            type_info = arg.rsplit(".", 1)
+            if len(type_info) != 2:
                 return None
 
             for c in all_classes:
                 for e in c.enums:
-                    if e.name == cpp_type_info[1] and cpp_type_info[0] == c.cpp_name:
+                    if e.name == type_info[1] and type_info[0] == c.name:
                         return c, e
 
             return None

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -501,6 +501,7 @@ def write_out_classes(
             enums_info=c.enums,
             referenced_enums=referenced_enums,
             libraries=all_libraries,
+            cpp_as_py_namespace=c_ns,
         )
 
         with class_file.open("wt") as out:

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -1,4 +1,5 @@
 import logging
+from re import split
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -272,10 +273,9 @@ def py_type_from_cpp(
 
     # Last resort, it is an enum. We need to strip the last name off, see if we can do the lookup.
     # If so, check for the enum in the class.
-    last_space = cpp_class_name.rfind("::")
-    if last_space >= 0:
-        enum_name = cpp_class_name[last_space + 2 :]  # noqa
-        enum_ns = cpp_class_name[:last_space]
+    split_result = cpp_class_name.rsplit("::", 1)
+    if len(split_result) == 2:
+        enum_ns, enum_name = split_result
         py_type = cpp_class_dict.get(enum_ns, None)
         if py_type is not None:
             for e in py_type.enums:

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -489,6 +489,7 @@ def write_out_classes(
         # Write out the object file
         text = class_template_file.render(
             class_name=c_name,
+            full_class_name=c.name,
             methods=c.methods,
             include_files=all_includes,
             import_statements=import_statements,

--- a/func_adl_servicex_type_generator/package.py
+++ b/func_adl_servicex_type_generator/package.py
@@ -409,7 +409,7 @@ def write_out_classes(
             return r
 
         def lookup_enum(
-            arg: method_arg_info, all_classes: Iterable[class_info]
+            arg: str, all_classes: Iterable[class_info]
         ) -> Optional[Tuple[class_info, enum_info]]:
             """Return the enum info for the argument if it is an enum.
 
@@ -423,7 +423,7 @@ def write_out_classes(
             # Split into namespace and enum type. We don't deal with
             # global enums here, so if this isn't a class-enum, then
             # just return.
-            cpp_type = clean_cpp_type(arg.arg_type)
+            cpp_type = clean_cpp_type(arg)
             if cpp_type is None:
                 return None
             cpp_type_info = cpp_type.rsplit(".", 2)
@@ -451,8 +451,10 @@ def write_out_classes(
             """
             return [
                 e_info
-                for arg in m.arguments
-                if (e_info := lookup_enum(arg, all_classes)) is not None
+                for arg in [a.arg_type for a in m.arguments]
+                + [py_type_from_cpp(m.return_type, cpp_all_classes_dict)]
+                if (arg is not None)
+                and (e_info := lookup_enum(arg, all_classes)) is not None
             ]
 
         def generate_enums(

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -24,7 +24,7 @@ _method_map = {
 {%- endfor %}
 }
 
-_enum_map = {
+_enum_function_map = {
 {%- for method_name in referenced_enums.keys() %}
     '{{ method_name }}': [
 {%- for enum in referenced_enums[method_name] %}
@@ -68,7 +68,7 @@ def _add_method_metadata(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[
             'link_libraries': ["{{ l_file }}"],
         })
 {% endfor %}
-        for md in _enum_map.get(a.func.attr, []):
+        for md in _enum_function_map.get(a.func.attr, []):
             s_update = s_update.MetaData(md)
         return s_update, a
     else:

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -43,10 +43,46 @@ _enum_function_map = {
 {%- endfor %}      
 }
 
+_defined_enums = {
+{%- for enum in enums_info %}
+    '{{ enum.name }}':
+        {
+            'metadata_type': 'define_enum',
+            'namespace': '{{ full_class_name }}',
+            'name': '{{ enum.name }}',
+            'values': [
+            {%- for value in enum.values %}
+                '{{ value.name }}',
+            {%- endfor %}
+            ],
+        },
+{%- endfor %}      
+}
+
 _object_cpp_as_py_namespace="{{ cpp_as_py_namespace }}"
 
 T = TypeVar('T')
 
+def add_enum_info(s: ObjectStream[T], enum_name: str) -> ObjectStream[T]:
+    '''Use this to add enum definition information to the backend.
+
+    This can be used when you are writing a C++ function that needs to
+    make sure a particular enum is defined.
+
+    Args:
+        s (ObjectStream[T]): The ObjectStream that is being updated
+        enum_name (str): Name of the enum
+
+    Raises:
+        ValueError: If it is not known, a list of possibles is printed out
+
+    Returns:
+        ObjectStream[T]: Updated object stream with new metadata.
+    '''
+    if enum_name not in _defined_enums:
+        raise ValueError(f"Enum {enum_name} is not known - "
+                            f"choose from one of {','.join(_defined_enums.keys())}")
+    return s.MetaData(_defined_enums[enum_name])
 
 def _add_method_metadata(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T], ast.Call]:
     '''Add metadata for a collection to the func_adl stream if we know about it

--- a/template/files/object.py
+++ b/template/files/object.py
@@ -43,6 +43,8 @@ _enum_map = {
 {%- endfor %}      
 }
 
+_object_cpp_as_py_namespace="{{ cpp_as_py_namespace }}"
+
 T = TypeVar('T')
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -871,6 +871,58 @@ def test_class_with_other_class_enum_in_arg(tmp_path, template_path):
     assert "'namespace': 'EnumOnly'" in class_text
 
 
+def test_class_with_other_class_enum_in_return(tmp_path, template_path):
+    """Two classes. One with enums, and the other class uses
+    those enums. Used in the return.
+
+    - Make sure the import works correctly
+    - Make sure the enum is fully qualified in its reference.
+    """
+    classes = [
+        class_info(
+            "Jets",
+            "Jets",
+            [
+                method_info(
+                    name="pt_enum",
+                    return_type="xAOD::VxType::VertexType",
+                    arguments=[],
+                    param_arguments=[],
+                    param_helper=None,
+                )
+            ],
+            None,
+            None,
+            "jet.hpp",
+        ),
+        class_info(
+            "xAOD.VxType",
+            "xAOD::VxType",
+            [],
+            None,
+            None,
+            "enums.hpp",
+            enums=[
+                enum_info(
+                    name="VertexType",
+                    values=[enum_value_info("NoVtx", 1), enum_value_info("PriVtx", 2)],
+                )
+            ],
+        ),
+    ]
+
+    write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
+
+    assert (tmp_path / "jets.py").exists()
+    class_text = (tmp_path / "jets.py").read_text()
+
+    assert "def pt_enum(self) -> package.xAOD.vxtype.VxType.VertexType" in class_text
+    assert "import package" in class_text
+
+    assert "define_enum" in class_text
+    assert "'namespace': 'xAOD.VxType'" in class_text
+
+
 def test_class_with_enum_and_int(tmp_path, template_path):
     """Make sure to reference a local enum in the class that has specific integer types
     correctly.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -921,6 +921,7 @@ def test_class_with_other_class_enum_in_return(tmp_path, template_path):
 
     assert "define_enum" in class_text
     assert "'namespace': 'xAOD.VxType'" in class_text
+    assert '_object_cpp_as_py_namespace=""' in class_text
 
 
 def test_class_with_enum_and_int(tmp_path, template_path):
@@ -1099,6 +1100,8 @@ def test_class_namespace(tmp_path, template_path):
     write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
 
     assert (tmp_path / "xAOD" / "jets.py").exists()
+    jet_text = (tmp_path / "xAOD" / "jets.py").read_text()
+    assert '_object_cpp_as_py_namespace="xAOD"' in jet_text
 
     assert (tmp_path / "xAOD" / "__init__.py").exists()
     init_text = (tmp_path / "xAOD" / "__init__.py").read_text()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -697,8 +697,8 @@ def test_class_simple(tmp_path, template_path):
     assert 'jets = _load_me("package.jets")' in init_text
 
 
-def test_class_with_just_enum(tmp_path, template_path):
-    """Write out a very simple top level class with enum
+def test_class_with_just_enum_decl(tmp_path, template_path):
+    """Write out a very simple top level class with enum, but the enum is not used.
 
     Args:
         tmp_path ([type]): [description]
@@ -728,7 +728,95 @@ def test_class_with_just_enum(tmp_path, template_path):
     assert "'metadata_type': 'define_enum'" not in class_text
 
 
-def test_class_with_external_enum(tmp_path, template_path):
+def test_class_with_enum_in_arg(tmp_path, template_path):
+    """Make sure to reference a local enum in the class method, and set metadata
+    correctly.
+    """
+    classes = [
+        class_info(
+            "Jets",
+            "Jets",
+            [
+                method_info(
+                    name="pt_enum",
+                    return_type="float",
+                    arguments=[method_arg_info("color", None, "Jets.Color")],
+                    param_arguments=[],
+                    param_helper=None,
+                )
+            ],
+            None,
+            None,
+            "jet.hpp",
+            enums=[
+                enum_info(
+                    name="Color",
+                    values=[enum_value_info("Red", 1), enum_value_info("Blue", 2)],
+                )
+            ],
+        ),
+    ]
+
+    write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
+
+    assert (tmp_path / "jets.py").exists()
+    assert (tmp_path / "__init__.py").exists()
+
+    class_text = (tmp_path / "jets.py").read_text()
+    assert "class Color(Enum)" in class_text
+    assert "def pt_enum(self, color: Jets.Color) -> float" in class_text
+
+    assert "'metadata_type': 'define_enum'" in class_text
+    assert "'namespace': 'Jets'" in class_text
+    assert "'name': 'Color'" in class_text
+    assert "'Red'" in class_text
+
+
+def test_class_with_enum_in_return(tmp_path, template_path):
+    """Make sure to reference a local enum in the class method return type, and set metadata
+    correctly.
+    """
+    classes = [
+        class_info(
+            "Jets",
+            "Jets",
+            [
+                method_info(
+                    name="pt_enum",
+                    return_type="Jets::Color",
+                    arguments=[],
+                    param_arguments=[],
+                    param_helper=None,
+                )
+            ],
+            None,
+            None,
+            "jet.hpp",
+            enums=[
+                enum_info(
+                    name="Color",
+                    values=[enum_value_info("Red", 1), enum_value_info("Blue", 2)],
+                )
+            ],
+        ),
+    ]
+
+    write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
+
+    assert (tmp_path / "jets.py").exists()
+    assert (tmp_path / "__init__.py").exists()
+
+    class_text = (tmp_path / "jets.py").read_text()
+    assert "class Color(Enum)" in class_text
+    assert "def pt_enum(self) -> package.jets.Jets.Color" in class_text
+
+    assert "'metadata_type': 'define_enum'" in class_text
+    assert "'namespace': 'Jets'" in class_text
+    assert "'name': 'Color'" in class_text
+    assert "'Red'" in class_text
+
+
+def test_class_with_other_class_enum_in_arg(tmp_path, template_path):
     """Two classes. One with enums, and the other class uses
     those enums.
 
@@ -783,52 +871,8 @@ def test_class_with_external_enum(tmp_path, template_path):
     assert "'namespace': 'EnumOnly'" in class_text
 
 
-def test_class_with_referenced_enum(tmp_path, template_path):
-    """Make sure to reference a local enum in the class, and set metadata
-    correctly.
-    """
-    classes = [
-        class_info(
-            "Jets",
-            "Jets",
-            [
-                method_info(
-                    name="pt_enum",
-                    return_type="float",
-                    arguments=[method_arg_info("color", None, "Jets.Color")],
-                    param_arguments=[],
-                    param_helper=None,
-                )
-            ],
-            None,
-            None,
-            "jet.hpp",
-            enums=[
-                enum_info(
-                    name="Color",
-                    values=[enum_value_info("Red", 1), enum_value_info("Blue", 2)],
-                )
-            ],
-        ),
-    ]
-
-    write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
-
-    assert (tmp_path / "jets.py").exists()
-    assert (tmp_path / "__init__.py").exists()
-
-    class_text = (tmp_path / "jets.py").read_text()
-    assert "class Color(Enum)" in class_text
-    assert "def pt_enum(self, color: Jets.Color) -> float" in class_text
-
-    assert "'metadata_type': 'define_enum'" in class_text
-    assert "'namespace': 'Jets'" in class_text
-    assert "'name': 'Color'" in class_text
-    assert "'Red'" in class_text
-
-
 def test_class_with_enum_and_int(tmp_path, template_path):
-    """Make sure to reference a local enum in the class, and set metadata
+    """Make sure to reference a local enum in the class that has specific integer types
     correctly.
     """
     classes = [

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -725,7 +725,34 @@ def test_class_with_just_enum_decl(tmp_path, template_path):
     assert "Red = 1" in class_text
     assert "from enum import Enum" in class_text
 
-    assert "'metadata_type': 'define_enum'" not in class_text
+    assert "'metadata_type': 'define_enum'" in class_text
+
+
+def test_class_namespace_with_just_enum_decl(tmp_path, template_path):
+    """Write out a very simple top level class with enum, but the enum is not used.
+
+    Args:
+        tmp_path ([type]): [description]
+    """
+    classes = [
+        class_info(
+            "xAOD.Jets",
+            "xAOD::Jets",
+            [],
+            None,
+            None,
+            "jet.hpp",
+            enums=[enum_info(name="Color", values=[enum_value_info("Red", 1)])],
+        ),
+    ]
+
+    write_out_classes(classes, template_path, tmp_path, "package", [""], "22")
+
+    assert (tmp_path / "xAOD" / "jets.py").exists()
+
+    class_text = (tmp_path / "xAOD" / "jets.py").read_text()
+    assert "'metadata_type': 'define_enum'" in class_text
+    assert "'namespace': 'xAOD.Jets'," in class_text
 
 
 def test_class_with_enum_in_arg(tmp_path, template_path):
@@ -959,7 +986,7 @@ def test_class_with_enum_and_int(tmp_path, template_path):
     assert (tmp_path / "__init__.py").exists()
 
     class_text = (tmp_path / "jets.py").read_text()
-    assert "'metadata_type': 'define_enum'" not in class_text
+    assert class_text.count("'metadata_type': 'define_enum'") == 1
 
 
 def test_class_with_just_enums(tmp_path, template_path):


### PR DESCRIPTION
* Enum's that are returned from methods now also trigger metadata uploads.
* Added ability to call `add_enum_info` that user can use when they need to trigger this (comes up in C++ code)

Fixes #43